### PR TITLE
Update submodule and add repository

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -25,3 +25,4 @@ mb_class = Module::Build::AlienLibJIT
 [PodSyntaxTests]
 [PodCoverageTests]
 [PodWeaver]
+[Repository]


### PR DESCRIPTION
Hello,

Testing locally and in github ci this module gives me an error during build. It is linked to a texi doc syntax (@center{blah blah}) that no longer works with more recent texinfo (see libjit upstream commit fixing it: http://git.savannah.gnu.org/cgit/libjit.git/commit/doc/libjit.texi?id=d8de1cd262c43d14992971b4595a3c0ad71c1925)

I updated the submodule and added the meta info for repository.